### PR TITLE
테스트 코드를 src/test/java 로 이동

### DIFF
--- a/mybatis-example-jdbc/pom.xml
+++ b/mybatis-example-jdbc/pom.xml
@@ -15,17 +15,4 @@
     <version>0.0.1.BUILD-SNAPSHOT</version>
 
     <name>mybatis-example-jdbc</name>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <mainClass>ldg.mybatis.CommentJdbcRepositoryTest</mainClass>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/mybatis-example-jdbc/src/main/java/ldg/mybatis/repository/CommentJdbcRepository.java
+++ b/mybatis-example-jdbc/src/main/java/ldg/mybatis/repository/CommentJdbcRepository.java
@@ -1,4 +1,4 @@
-package ldg.mybatis.repository.session;
+package ldg.mybatis.repository;
 
 import ldg.mybatis.model.Comment;
 

--- a/mybatis-example-jdbc/src/test/java/ldg/mybatis/repository/CommentJdbcRepositoryTest.java
+++ b/mybatis-example-jdbc/src/test/java/ldg/mybatis/repository/CommentJdbcRepositoryTest.java
@@ -1,7 +1,6 @@
-package ldg.mybatis;
+package ldg.mybatis.repository;
 
 import ldg.mybatis.model.Comment;
-import ldg.mybatis.repository.session.CommentJdbcRepository;
 
 import java.util.*;
 


### PR DESCRIPTION
/src/test/java 소스에 main( ) 메소드가 있는 테스트 코드를 위치시켜도 maven의 test 수명 주기로 돌릴 수 있음을 알게 되어
테스트 코드를 /src/test/java 아래로 옮김.

main() 메소드를 포함한 테스트 코드를 test 수명 주기에서 구동할 수 있기 때문에 maven-exec-plugin이 불필요해짐. pom.xml에서 해당 플러그인 제거